### PR TITLE
添加 ItsPaint 到 Mac 实用工具箱

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Awesome Tools，程序员常用高效实用工具、软件资源精选，办公�
 | DevHub | DevHub是一个免费开发者工具箱 100+ 实用小工具合集 (Mac/离线使用)，经过精心打造，旨在支持开发人员的日常任务，并确保其数据的最高安全性。 | https://wangchujiang.com/DevHub/index.zh.html |
 | uTools | uTools是一款功能丰富、高度可定制的桌面软件（实用工具箱）支持Windows, Mac, Linux版本，通过集成多种实用插件，为用户提供了一个便捷高效的工作平台。无论是专业人士还是普通用户，都能在uTools中找到适合自己的功能，提高工作效率和生活品质。如果你正在寻找一款能够提升工作效率的桌面软件，uTools绝对是一个值得尝试的选择。 | https://u.tools/download |
 | MooTool | MooTool 是一个功能丰富、跨平台（Windows • Linux • macOS）、开源免费的开发者工具箱，能够显著提高开发效率，简化开发流程。无论是代码编写与调试、数据处理与转换、网络请求调试还是加密解密与安全等方面，MooTool 都能提供有力的支持。 | https://github.com/rememberber/MooTool |
-|  |  |  |
+| ItsPaint | ItsPaint 是一款开源免费（MIT 协议）的 macOS 原生画图工具，支持画笔、图形、文字标注、马赛克和自动编号步骤标记，可导出 PNG/JPEG/GIF/HEIC/AVIF/PDF/ICO 等格式，安装包仅 2.9 MB，无网络请求、无遥测。 | https://github.com/joshlin2201/itspaint |
 |  |  |  |
 |  |  |  |
 


### PR DESCRIPTION
在 **🍎Mac实用工具箱** 中添加 [ItsPaint](https://github.com/joshlin2201/itspaint)。

ItsPaint 是一款 macOS 原生的画图和截图标注工具，MIT 开源协议，Mac App Store 上免费，安装包 2.9 MB。可以新建任意尺寸的空白画布、裁剪、把一张图片贴到另一张上面；截图标注支持自动编号的步骤标记和局部马赛克，适合写文档和提 Bug。11 个工具、15 种图形、9 种导出格式。

**完全没有网络代码，也没有申请任何网络权限**，所以系统内核会直接拒绝对外连接。README 里有三条命令可以自己验证。

使用了表格中预留的空行，未改动其他内容。

---

Adding ItsPaint to the Mac tools table, using one of the blank rows the table reserves for new entries. Native macOS paint and screenshot markup app, MIT, free on the Mac App Store, 2.9 MB, with no network code and no network entitlement at all.
