### PR TITLE
Add DSH Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Awesome Tools，程序员常用高效实用工具、软件资源精选，办公�
 | codex-profiles | codex-profiles 是一个无依赖的 Bash 工具，可通过独立的 CODEX_HOME 切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口；不会复制或读取认证令牌。 | https://github.com/Ducksss/codex-profiles |
 | Huiyu-Pi | Huiyu-Pi 是一款本地优先的 AI 编程助手，提供纯浏览器 Web UI。核心优势：~80 tokens 系统提示（接近零上下文）、~0.3s 首字响应、成本降低 90%+。支持 Claude、GPT、DeepSeek、Gemini 等多种 LLM 一键切换。内置文件浏览器、Monaco 代码编辑器、xterm 终端、Git 集成。一行命令启动（npx pi-forge），完全本地部署，MIT 开源免费。 | https://github.com/huiyu9144/Huiyu-Pi |
 | Tura | Tura 是一款本地开源 AI 编码代理，支持自定义模型供应商，提供 CLI、TUI 和跨平台桌面界面；项目还公开长时程任务中逐轮的工具调用、令牌用量、补丁及验证结果。 | https://github.com/Tura-AI/tura |
+| DSH Studio | DSH Studio 是一款 MIT 开源的跨平台桌面工具，可一键安装、启动和监控 DeepSeek Harness，并提供运行状态检查及进程树清理，支持 Windows、macOS 与 Linux。 | https://github.com/Moresyl/dsh-studio |
 |  |  |  |
 |  |  |  |
 |  |  |  |


### PR DESCRIPTION
## Summary

在 **💥AI辅助编程工具** 中新增 [DSH Studio](https://github.com/Moresyl/dsh-studio)。

## 工具简介

- MIT 开源的跨平台桌面工具
- 一键安装、启动和监控 DeepSeek Harness
- 提供运行状态检查与进程树清理
- 支持 Windows、macOS 与 Linux

## 链接

https://github.com/Moresyl/dsh-studio

感谢维护本列表！