### PR TITLE
Add Focuh to Mac实用工具箱

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ Awesome Tools，程序员常用高效实用工具、软件资源精选，办公�
 | uTools | uTools是一款功能丰富、高度可定制的桌面软件（实用工具箱）支持Windows, Mac, Linux版本，通过集成多种实用插件，为用户提供了一个便捷高效的工作平台。无论是专业人士还是普通用户，都能在uTools中找到适合自己的功能，提高工作效率和生活品质。如果你正在寻找一款能够提升工作效率的桌面软件，uTools绝对是一个值得尝试的选择。 | https://u.tools/download |
 | MooTool | MooTool 是一个功能丰富、跨平台（Windows • Linux • macOS）、开源免费的开发者工具箱，能够显著提高开发效率，简化开发流程。无论是代码编写与调试、数据处理与转换、网络请求调试还是加密解密与安全等方面，MooTool 都能提供有力的支持。 | https://github.com/rememberber/MooTool |
 | ItsPaint | ItsPaint 是一款开源免费（MIT 协议）的 macOS 原生画图工具，支持画笔、图形、文字标注、马赛克和自动编号步骤标记，可导出 PNG/JPEG/GIF/HEIC/AVIF/PDF/ICO 等格式，安装包仅 2.9 MB，无网络请求、无遥测。 | https://github.com/joshlin2201/itspaint |
-|  |  |  |
+| Focuh | Focuh 是一款免费的 macOS ADHD 待办与周计划工具，内置专注计时器和系统级网站/应用屏蔽，另有配套网页版。签名公证，支持 Apple Silicon 与 Intel。 | https://www.focuh.com |
 |  |  |  |
 
 [🔝返回目录](https://github.com/YSGStudyHards/Awesome-Tools/tree/main?tab=readme-ov-file#%E7%9B%AE%E5%BD%95%E5%AF%BC%E8%88%AA%E5%96%84%E7%94%A8ctrlf)


### PR DESCRIPTION
## Summary
Add [Focuh](https://www.focuh.com) to **🍎Mac实用工具箱**.

Focuh is a free macOS ADHD todo list and week planner with a focus timer and system-wide website/app blocking, plus a matching web app. Signed and notarized; Apple Silicon and Intel.

## Disclosure
I am the developer of Focuh.

## Checklist
- [x] Added as a table row in the existing Mac section format
- [x] Homepage link only (no /live, no invented metrics)
- [x] Free / freeware product