### PR TITLE
添加 AI Novel Writer 到 AI 实用效率工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Awesome Tools，程序员常用高效实用工具、软件资源精选，办公�
 ## 🤖AI实用效率工具
 |                工具名称                |                           工具详细介绍                           |           工具开源、下载地址            |
 | :-------------------------------------------: | :----------------------------------------------------------: | :-------------------------------: |
+| AI Novel Writer | AI Novel Writer 是一款面向长篇小说创作的开源、本地优先桌面工作台，把故事前提、角色、世界观、大纲、章节蓝图、草稿、审稿和修订放在同一个项目流程中。支持 Windows、macOS、Ollama 及用户自行配置的模型服务，所有模型建议均由作者审核后决定是否采用。 | [官网](https://www.orz.md/ai-novel-writer/) / [GitHub](https://github.com/EthanYoQ/AI-Novel-Writer) |
 | WorkBuddy | WorkBuddy 是由腾讯推出的智能办公助手，它通过AI技术深度集成文档处理、数据分析、会议管理和自动化流程等核心功能，能够帮助用户快速总结文档、生成报告、整理会议纪要，并连接企业系统实现自然语言指令操作。其特点是深度融入腾讯文档、企业微信等生态，提供安全可靠的企业级服务，支持私有化部署，并针对中文办公场景进行优化，适合企业团队及职场人士提升效率、简化工作流程，实现智能协作与决策。 | [https://www.codebuddy.cn/fission](https://www.codebuddy.cn/fission/?inviteCode=aht9pm7xu85dklj) |
 | OpenClaw | OpenClaw 是一款本地优先、完全开源的新一代 AI 助手。它直接部署在你的 macOS、Windows 或 Linux 设备（及服务器）上，将大模型的智慧与您的操作系统深度融合。它不仅能理解上下文，更拥有长时记忆与系统级权限，能真正“动手”执行文件管理、数据抓取、应用操控等真实任务。OpenClaw 不是一个普通的聊天机器人，而是一个住在你电脑里的私人秘书，它能通过微信、WhatsApp、Telegram 等聊天软件接收指令，帮你发邮件、查日历、打开浏览器、运行命令，甚至 24 小时自动做事！ | https://github.com/openclaw/openclaw |
 | Hermes Agent | Hermes Agent 是一款由 Nous Research 开发的开源（MIT license）免费的自托管 AI 智能体框架，与其他 AI 助手工具不同，Hermes Agent 具备真正的自我进化能力它能在与你的每次对话中自动学习、提炼技能、更新记忆，让智能体随使用时间持续成长。 | https://github.com/NousResearch/hermes-agent |


### PR DESCRIPTION
新增 AI Novel Writer：面向长篇小说创作的开源、本地优先桌面工作台。条目说明了真实工作流、Windows/macOS 支持、Ollama 接入和作者审核边界。

项目：https://github.com/EthanYoQ/AI-Novel-Writer